### PR TITLE
[Fix] Change The Working Dir To An Empty Folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 COPY --from=builder /usr/src/app/target/release/stakpak /usr/local/bin
 RUN chmod +x /usr/local/bin/stakpak
 
-WORKDIR /apps/
+WORKDIR /agent/
 
 # Create docker group
 RUN groupadd -r docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 COPY --from=builder /usr/src/app/target/release/stakpak /usr/local/bin
 RUN chmod +x /usr/local/bin/stakpak
 
+WORKDIR /apps/
+
 # Create docker group
 RUN groupadd -r docker
 


### PR DESCRIPTION
This allows anyone using the image to make his customization.

- Make mounting easy with custom files
- Easier to pass project files to the agents
- if the agent manages to clone a repo, it will be in `/apps/`